### PR TITLE
Include OpenCL 2.x read-write access mode for images in SYCL mode

### DIFF
--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -547,7 +547,7 @@ ALIAS("kernel", __kernel            , KEYOPENCLC|KEYOPENCLCXX)
 // OpenCL access qualifiers
 KEYWORD(__read_only                 , KEYOPENCLC|KEYOPENCLCXX|KEYSYCL)
 KEYWORD(__write_only                , KEYOPENCLC|KEYOPENCLCXX|KEYSYCL)
-KEYWORD(__read_write                , KEYOPENCLC|KEYOPENCLCXX)
+KEYWORD(__read_write                , KEYOPENCLC|KEYOPENCLCXX|KEYSYCL)
 ALIAS("read_only", __read_only      , KEYOPENCLC|KEYOPENCLCXX)
 ALIAS("write_only", __write_only    , KEYOPENCLC|KEYOPENCLCXX)
 ALIAS("read_write", __read_write    , KEYOPENCLC|KEYOPENCLCXX)


### PR DESCRIPTION
While not yet supported by the triSYCL run-time, add this so there will
be no astonishment the day it is implemented.